### PR TITLE
composite ideas

### DIFF
--- a/test-1/test1.ipynb
+++ b/test-1/test1.ipynb
@@ -821,7 +821,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "workflows",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
pktools is a bash commandline tool that we could use

xarray is throwing up errors

Note: CEDA catalogue was down, hence the access errors 